### PR TITLE
cond/case & ^:const

### DIFF
--- a/src/shen/overwrite.clj
+++ b/src/shen/overwrite.clj
@@ -29,12 +29,11 @@
 (defun
   boolean?
   (V746)
-  (c/condp = V746
-             true true
-             false true
-             (intern "true") true
-             (intern "false") true
-             false))
+  (c/cond (= true V746) true
+          (= false V746) true
+          (= "true" (intern V746)) true
+          (= "false" (intern V746)) true
+          :else false))
 
 (defun
   shen-compose
@@ -58,7 +57,7 @@
 
 ;; Based on [Shen Mode](https://github.com/eschulte/shen-mode) by Eric Schulte.
 ;; - Shen functions taken largely from the Qi documentation by Dr. Mark Tarver.
-(def ^:private shen-doc
+(def ^:private ^:const shen-doc
   `((* "number --> number --> number" "Number multiplication.")
     (+ "number --> number --> number" "Number addition.")
     (- "number --> number --> number" "Number subtraction.")


### PR DESCRIPTION
- ^:const is ever so slightly faster then no ^:const
- cond/case are faster than condp:

```
user=> (time (dotimes [i 100000] (condp = i 1 2 3 4 5 6 7 8 9)))
"Elapsed time: 36.561 msecs"
nil
user=> (time (dotimes [i 100000] (case i 1 2 3 4 5 6 7 8 9)))
"Elapsed time: 2.331 msecs"
nil
user=> (time (dotimes [i 100000] (cond (= i 1) 2 (= i 3) 4  (= i 5) 6  (= i 7) 8 :else 9)))
"Elapsed time: 2.309 msecs"
```
